### PR TITLE
Updated to newer Latex Version

### DIFF
--- a/coloremoji.sty
+++ b/coloremoji.sty
@@ -33,7 +33,7 @@
   }%
  }
 
-\bool_if:nTF { \xetex_if_engine_p: || \luatex_if_engine_p: }
+\bool_if:nTF { \sys_if_engine_xetex_p: || \sys_if_engine_luatex_p: }
   {
    \cs_set_eq:NN \coloremoji \coloremoji_unicode:n
   }


### PR DESCRIPTION
Fixes the following errors found for new Versions of Latex
The deprecated command '\xetex_if_engine_p:' has been or will be removed on 2017-01-01. Use instead '\sys_if_engine_xetex_p: 
The deprecated command '\luatex_if_engine_p:' has been or will be removed on 2017-01-01. Use instead '\sys_if_engine_luatex_p: 

